### PR TITLE
feature/job-restart-stanza

### DIFF
--- a/dp-performance-reporter.nomad
+++ b/dp-performance-reporter.nomad
@@ -20,6 +20,13 @@ job "dp-performance-reporter" {
       value     = "publishing.*"
     }
 
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
     task "dp-performance-reporter" {
       driver = "docker"
 


### PR DESCRIPTION
### What

Add restart stanza to job plan. Once upgraded to Nomad 0.8.4 we can control how our jobs our restarted.

### How to review

Check the plan is valid with Nomad 0.8+ and looks OK.

### Who can review

Not me.
