### PR TITLE
removed operator:regexp

### DIFF
--- a/dp-performance-reporter.nomad
+++ b/dp-performance-reporter.nomad
@@ -16,8 +16,7 @@ job "dp-performance-reporter" {
 
     constraint {
       attribute = "${node.class}"
-      operator  = "regexp"
-      value     = "publishing.*"
+      value     = "publishing"
     }
 
     restart {


### PR DESCRIPTION
### What

Updated nomad plans to removed operator:regexp and attribute:meta.has_disk.
Could not find dp-api-poc or dp-developer-poc.
https://trello.com/c/wKGU1LY5/3697-check-all-bau-services-nomad-plans

### How to review

???

### Who can review

james
